### PR TITLE
Add league selector header to analyzer and tweak roster layout

### DIFF
--- a/dh_0829/analyzer/analyzer.html
+++ b/dh_0829/analyzer/analyzer.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&family=Product+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="../styles/styles.css" rel="stylesheet">
     <style>
         :root {
             --font-sans: 'Product Sans', 'Google Sans', 'Quicksand', sans-serif;
@@ -140,14 +141,49 @@
 
     </style>
 </head>
-<body class="px-2 pb-4 md:px-8 md:pb-8">
-    <div id="starfield">
+<body data-page="analyzer" class="p-2 sm:p-4">
+    <div aria-hidden="true" id="starfield">
+        <div id="stars"></div>
         <div id="stars1"></div>
         <div id="stars2"></div>
         <div id="stars3"></div>
     </div>
+    <div id="noise-overlay"></div>
 
-    <div class="max-w-7xl mx-auto space-y-2 md:space-y-4">
+    <div class="relative z-10 content-wrapper">
+    <div id="header-container">
+        <header class="app-header glass-panel">
+            <div class="header-row">
+                <div class="menu-container">
+                    <button id="menu-button" class="menu-button">
+                        <svg viewBox="0 0 100 80" width="20" height="20">
+                            <rect width="100" height="15"></rect>
+                            <rect y="30" width="100" height="15"></rect>
+                            <rect y="60" width="100" height="15"></rect>
+                        </svg>
+                    </button>
+                    <div id="dropdown-menu" class="dropdown-menu hidden">
+                        <a href="../">Home</a>
+                        <a href="#" id="menu-rosters">Rosters</a>
+                        <a href="#" id="menu-ownership">Ownership</a>
+                        <a href="#" id="menu-analyzer">League Analyzer</a>
+                        <a href="#">Placeholder</a>
+                    </div>
+                </div>
+                <div class="username-area">
+                    <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
+                </div>
+                <div class="custom-select-wrapper hidden" id="leagueSelectWrapper">
+                    <select disabled id="leagueSelect">
+                        <option>Select a league...</option>
+                    </select>
+                </div>
+            </div>
+        </header>
+    </div>
+
+    <main class="container mx-auto" id="content">
+        <div class="max-w-7xl mx-auto space-y-2 md:space-y-4">
         <!-- Header -->
         <header class="text-center space-y-2">
             <h1 class="text-2xl md:text-3xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
@@ -155,16 +191,10 @@
         </header>
 
         <!-- Controls -->
-        <div class="glass-panel py-1 px-2 flex flex-col md:flex-row items-center justify-center gap-1" style="display: none;">
-            <input type="text" id="usernameInput" placeholder="Enter Sleeper Username" class="px-3 py-1 text-sm w-full md:w-auto">
-            <div id="leagueSelectWrapper" class="hidden w-full md:w-auto">
-                <select id="leagueSelect" class="px-3 py-1 text-sm w-full md:w-auto appearance-none">
-                    <option>Select a league...</option>
-                </select>
-            </div>
+        <div class="glass-panel py-1 px-2 flex items-center justify-center" id="analyzerControls">
             <button id="fetchDataButton" class="bg-purple-600/50 hover:bg-purple-700/50 text-white font-bold text-sm py-1 px-3 w-full md:w-auto">Analyze League</button>
         </div>
-        
+
         <!-- Summary Stats -->
         <section id="summaryStats" class="hidden grid grid-cols-4 lg:grid-cols-8 gap-1 md:gap-4 text-center my-2 md:my-0">
             <!-- Summary boxes injected here -->
@@ -209,8 +239,11 @@
                 </div>
             </section>
         </main>
+        </div>
+    </main>
     </div>
 
+    <script defer src="../scripts/app.js?v=20250826235225"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const params = new URLSearchParams(window.location.search);

--- a/dh_0829/scripts/app.js
+++ b/dh_0829/scripts/app.js
@@ -47,12 +47,13 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         });
 
         menuRosters?.addEventListener('click', () => {
-            if (pageType === 'welcome') {
-                const username = usernameInput.value.trim();
-                if (!username) return;
-                window.location.href = `rosters/rosters.html?username=${encodeURIComponent(username)}`;
-            } else {
+            const username = usernameInput.value.trim();
+            if (!username) return;
+            if (pageType === 'rosters') {
                 handleFetchRosters();
+            } else {
+                const prefix = pageType === 'welcome' ? '' : '../';
+                window.location.href = `${prefix}rosters/rosters.html?username=${encodeURIComponent(username)}`;
             }
             dropdownMenu.classList.add('hidden');
         });
@@ -67,7 +68,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             window.location.href = url;
             dropdownMenu.classList.add('hidden');
         });
-
+        
         analyzeLeagueButton?.addEventListener('click', () => {
             const username = usernameInput.value.trim();
             if (!username || !state.currentLeagueId) return;
@@ -75,12 +76,13 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         });
 
         menuOwnership?.addEventListener('click', () => {
-            if (pageType === 'welcome') {
-                const username = usernameInput.value.trim();
-                if (!username) return;
-                window.location.href = `ownership/ownership.html?username=${encodeURIComponent(username)}`;
-            } else {
+            const username = usernameInput.value.trim();
+            if (!username) return;
+            if (pageType === 'ownership') {
                 handleFetchOwnership();
+            } else {
+                const prefix = pageType === 'welcome' ? '' : '../';
+                window.location.href = `${prefix}ownership/ownership.html?username=${encodeURIComponent(username)}`;
             }
             dropdownMenu.classList.add('hidden');
         });

--- a/dh_0829/styles/styles.css
+++ b/dh_0829/styles/styles.css
@@ -217,6 +217,10 @@
             width: 100%;
             padding-bottom: 2px; /* space for scrollbar */
         }
+        #contextual-controls .header-row:first-child {
+            gap: 0.25rem;
+            padding: 0 0.25rem;
+        }
         .header-row:nth-child(2), .header-row:nth-child(3) {
             border-top: 1px solid var(--color-panel-border);
             padding-top: 0.25rem;


### PR DESCRIPTION
## Summary
- Add shared top bar with league selector to league analyzer page
- Allow navigation from analyzer to rosters and ownership pages
- Tighten roster controls spacing for improved layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b26daf812c832eb982075417275bf0