### PR TITLE
feat: bring home navigation to analyzer

### DIFF
--- a/dh_0829/analyzer/analyzer.html
+++ b/dh_0829/analyzer/analyzer.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&family=Product+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="../styles/styles.css" rel="stylesheet"/>
     <style>
         :root {
             --font-sans: 'Product Sans', 'Google Sans', 'Quicksand', sans-serif;
@@ -140,43 +141,65 @@
 
     </style>
 </head>
-<body class="px-2 pb-4 md:px-8 md:pb-8">
+<body data-page="analyzer" class="p-2 sm:p-4">
     <div id="starfield">
+        <div id="stars"></div>
         <div id="stars1"></div>
         <div id="stars2"></div>
         <div id="stars3"></div>
     </div>
-
-    <div class="max-w-7xl mx-auto space-y-2 md:space-y-4">
-        <!-- Header -->
-        <header class="text-center space-y-2">
-            <h1 class="text-2xl md:text-3xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
-            <p class="text-md text-gray-400">KTC Team Value Analysis</p>
-        </header>
-
-        <!-- Controls -->
-        <div class="glass-panel py-1 px-2 flex flex-col md:flex-row items-center justify-center gap-1" style="display: none;">
-            <input type="text" id="usernameInput" placeholder="Enter Sleeper Username" class="px-3 py-1 text-sm w-full md:w-auto">
-            <div id="leagueSelectWrapper" class="hidden w-full md:w-auto">
-                <select id="leagueSelect" class="px-3 py-1 text-sm w-full md:w-auto appearance-none">
-                    <option>Select a league...</option>
-                </select>
-            </div>
-            <button id="fetchDataButton" class="bg-purple-600/50 hover:bg-purple-700/50 text-white font-bold text-sm py-1 px-3 w-full md:w-auto">Analyze League</button>
+    <div id="noise-overlay"></div>
+    <div class="relative z-10 content-wrapper">
+        <div id="header-container">
+            <header class="app-header glass-panel">
+                <div class="header-row">
+                    <div class="menu-container">
+                        <button id="menu-button" class="menu-button">
+                            <svg viewBox="0 0 100 80" width="20" height="20">
+                                <rect width="100" height="15"></rect>
+                                <rect y="30" width="100" height="15"></rect>
+                                <rect y="60" width="100" height="15"></rect>
+                            </svg>
+                        </button>
+                        <div id="dropdown-menu" class="dropdown-menu hidden">
+                            <a href="../">Home</a>
+                            <a href="#" id="menu-rosters">Rosters</a>
+                            <a href="#" id="menu-ownership">Ownership</a>
+                            <a href="#" id="menu-analyzer">League Analyzer</a>
+                            <a href="#">Placeholder</a>
+                        </div>
+                    </div>
+                    <div class="username-area">
+                        <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text"/>
+                    </div>
+                    <div class="custom-select-wrapper">
+                        <select id="leagueSelect" disabled>
+                            <option>Select a league...</option>
+                        </select>
+                    </div>
+                    <button id="fetchDataButton" class="control-button">Analyze League</button>
+                </div>
+            </header>
         </div>
-        
-        <!-- Summary Stats -->
-        <section id="summaryStats" class="hidden grid grid-cols-4 lg:grid-cols-8 gap-1 md:gap-4 text-center my-2 md:my-0">
-            <!-- Summary boxes injected here -->
-        </section>
+        <main class="container mx-auto" id="content">
+            <div class="max-w-7xl mx-auto space-y-2 md:space-y-4">
+                <header class="text-center space-y-2">
+                    <h1 class="text-2xl md:text-3xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
+                    <p class="text-md text-gray-400">KTC Team Value Analysis</p>
+                </header>
 
-        <!-- Loading Indicator -->
-        <div id="loading" class="hidden text-center py-8">
-            <p class="text-2xl animate-pulse">Analyzing cosmic data streams...</p>
-        </div>
+                <!-- Summary Stats -->
+                <section id="summaryStats" class="hidden grid grid-cols-4 lg:grid-cols-8 gap-1 md:gap-4 text-center my-2 md:my-0">
+                    <!-- Summary boxes injected here -->
+                </section>
 
-        <!-- Main Content -->
-        <main id="infographicContent" class="hidden space-y-6">
+                <!-- Loading Indicator -->
+                <div id="loading" class="hidden text-center py-8">
+                    <p class="text-2xl animate-pulse">Analyzing cosmic data streams...</p>
+                </div>
+
+                <!-- Main Content -->
+                <section id="infographicContent" class="hidden space-y-6">
             <!-- Top Level Charts -->
             <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <div class="glass-panel p-2">
@@ -208,6 +231,7 @@
                     <!-- Grid items will be injected here by JavaScript -->
                 </div>
             </section>
+            </div>
         </main>
     </div>
 
@@ -225,6 +249,52 @@
             const infographicContent = document.getElementById('infographicContent');
             const starterRankingsGrid = document.getElementById('starterRankingsGrid');
             const summaryStats = document.getElementById('summaryStats');
+
+            const menuButton = document.getElementById('menu-button');
+            const dropdownMenu = document.getElementById('dropdown-menu');
+            const menuRosters = document.getElementById('menu-rosters');
+            const menuOwnership = document.getElementById('menu-ownership');
+            const menuAnalyzer = document.getElementById('menu-analyzer');
+
+            menuButton.addEventListener('click', (e) => {
+                e.stopPropagation();
+                dropdownMenu.classList.toggle('hidden');
+            });
+
+            document.addEventListener('click', (e) => {
+                if (!dropdownMenu.classList.contains('hidden') && !menuButton.contains(e.target)) {
+                    dropdownMenu.classList.add('hidden');
+                }
+            });
+
+            menuRosters.addEventListener('click', () => {
+                const uname = usernameInput.value.trim();
+                if (!uname) return;
+                let url = `../rosters/rosters.html?username=${encodeURIComponent(uname)}`;
+                if (state.currentLeagueId) {
+                    url += `&leagueId=${state.currentLeagueId}`;
+                }
+                window.location.href = url;
+                dropdownMenu.classList.add('hidden');
+            });
+
+            menuOwnership.addEventListener('click', () => {
+                const uname = usernameInput.value.trim();
+                if (!uname) return;
+                window.location.href = `../ownership/ownership.html?username=${encodeURIComponent(uname)}`;
+                dropdownMenu.classList.add('hidden');
+            });
+
+            menuAnalyzer.addEventListener('click', () => {
+                const uname = usernameInput.value.trim();
+                if (!uname) return;
+                let url = `analyzer.html?username=${encodeURIComponent(uname)}`;
+                if (state.currentLeagueId) {
+                    url += `&leagueId=${state.currentLeagueId}`;
+                }
+                window.location.href = url;
+                dropdownMenu.classList.add('hidden');
+            });
 
 
             // --- Chart instances ---
@@ -885,7 +955,6 @@
                     option.textContent = league.name;
                     leagueSelect.appendChild(option);
                 });
-                document.getElementById('leagueSelectWrapper').classList.remove('hidden');
                 leagueSelect.disabled = false;
             }
 

--- a/dh_0829/styles/styles.css
+++ b/dh_0829/styles/styles.css
@@ -231,6 +231,12 @@
             display: none;
         }
 
+        #contextual-controls > .header-row:first-child {
+            gap: 0.25rem;
+            padding-left: 0.25rem;
+            padding-right: 0.25rem;
+        }
+
 /* Ensure hidden truly hides views regardless of ID display rules */
 #playerListView.hidden, #rosterView.hidden { display: none !important; }
 


### PR DESCRIPTION
## Summary
- Add home-style navigation bar with username input, league selector, and analyze button to league analyzer page
- Allow switching leagues directly in analyzer and reuse selected league when navigating
- Tighten spacing on rosters page second-row controls for more balanced layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b26daf812c832eb982075417275bf0